### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# ----
+*                     @mxmehl
+/teams/osrd.yaml      @openrailassociation/OSRD-Admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # ----
-*                     @mxmehl
+*                     @mxmehl @cornelius
 /teams/osrd.yaml      @openrailassociation/OSRD-Admins


### PR DESCRIPTION
Here's a suggestion for adding code owners to files so each project can manage its org autonomously.

To make this PR useful we should change a few repository settings:

- Add branch protection for `main`:
  - Require a pull request before merging
  - Require review from Code Owners
  - Require status check to pass before merging
  - Require conversation resolution before merging 
  - Require linear history 
- Add write permissions to openrailassociation members

> [!NOTE]
> We could also add a check to ensure that the yaml file doesn't affect any groups other than the one for which it was created (`OSRD` group for the `osrd.yaml` file and so on...).