### PR TITLE
OSRD: allow team to change DNS records

### DIFF
--- a/teams/osrd.yaml
+++ b/teams/osrd.yaml
@@ -49,6 +49,8 @@ OSRD:
     osrd-website: push
     # GitHub Team Management
     openrail-org-config: push
+    # DNS Records
+    openrail-dns: push
 
 OSRD-Admins:
   parent: OSRD


### PR DESCRIPTION
Similar setup to `openrail-org-config`: OSRD team can push, but with CODEOWNERS and branch protection, there is still another check involved.

Concerns the new repo https://github.com/OpenRailAssociation/openrail-dns/