### PR TITLE
Add technical committee members

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # ----
 *                     @mxmehl @cornelius
 /teams/osrd.yaml      @openrailassociation/OSRD-Admins
+/teams/technical-committee.yaml      @openrailassociation/Technical-Committee-Maintainers

--- a/teams/general.yaml
+++ b/teams/general.yaml
@@ -1,23 +1,6 @@
 # ------------------------------------------------------------------------------
 # General OpenRail teams
 # ------------------------------------------------------------------------------
-Technical Committee:
-  maintainer: # Chair of the TC
-    - loic-hamelin
-  member:
-    - aiAdrian # NGE
-    - cornelius # appointed
-    - flomonster # OSRD
-    - frederik-db # DAC-DSS
-    - Keller-Peter # appointed
-    - mxmehl # permanent guest, OpenRail Team
-    - schalbts # RCM
-    - Tristramg # liblrs
-  repos:
-    technical-committee: push
-    # GitHub Team Management
-    openrail-org-config: push
-
 OpenRail Team:
   member:
     - cornelius

--- a/teams/general.yaml
+++ b/teams/general.yaml
@@ -2,11 +2,17 @@
 # General OpenRail teams
 # ------------------------------------------------------------------------------
 Technical Committee:
-  maintainer:
-    - cornelius
-  member:
-    - Keller-Peter
+  maintainer: # Chair of the TC
     - loic-hamelin
+  member:
+    - aiAdrian # NGE
+    - cornelius # appointed
+    - flomonster # OSRD
+    - frederik-db # DAC-DSS
+    - Keller-Peter # appointed
+    - mxmehl # permanent guest, OpenRail Team
+    - schalbts # RCM
+    - Tristramg # liblrs
   repos:
     technical-committee: push
     # GitHub Team Management

--- a/teams/technical-committee.yaml
+++ b/teams/technical-committee.yaml
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------------------
+# OpenRail Technical Committee
+# ------------------------------------------------------------------------------
+Technical Committee:
+  # Maintainers, see https://github.com/OpenRailAssociation/technical-committee/blob/main/MAINTAINERS.md
+  maintainer:
+    - cornelius # appointed
+    - Keller-Peter # appointed
+    - loic-hamelin # appointed
+    - mxmehl # permanent guest, OpenRail Team
+  # Members, see https://github.com/OpenRailAssociation/technical-committee/blob/main/README.md#members
+  member:
+    - aiAdrian # NGE
+    - flomonster # OSRD
+    - frederik-db # DAC-DSS
+    - schalbts # RCM
+    - Tristramg # liblrs
+  repos:
+    technical-committee: push
+    # GitHub Team Management
+    openrail-org-config: push

--- a/teams/technical-committee.yaml
+++ b/teams/technical-committee.yaml
@@ -4,7 +4,7 @@
 Technical Committee:
   # The members of the TC:
   # https://github.com/OpenRailAssociation/technical-committee/blob/main/README.md#members
-  # The maintainers (below) will be automatically become members of this team as well
+  # The maintainers (below) will automatically become members of this team as well
   member:
     - aiAdrian # NGE
     - flomonster # OSRD

--- a/teams/technical-committee.yaml
+++ b/teams/technical-committee.yaml
@@ -2,13 +2,9 @@
 # OpenRail Technical Committee
 # ------------------------------------------------------------------------------
 Technical Committee:
-  # Maintainers, see https://github.com/OpenRailAssociation/technical-committee/blob/main/MAINTAINERS.md
-  maintainer:
-    - cornelius # appointed
-    - Keller-Peter # appointed
-    - loic-hamelin # appointed
-    - mxmehl # permanent guest, OpenRail Team
-  # Members, see https://github.com/OpenRailAssociation/technical-committee/blob/main/README.md#members
+  # The members of the TC:
+  # https://github.com/OpenRailAssociation/technical-committee/blob/main/README.md#members
+  # The maintainers (below) will be automatically become members of this team as well
   member:
     - aiAdrian # NGE
     - flomonster # OSRD
@@ -17,5 +13,16 @@ Technical Committee:
     - Tristramg # liblrs
   repos:
     technical-committee: push
+
+Technical Committee Maintainers:
+  parent: Technical Committee
+  # The maintainers of the TC repo:
+  # https://github.com/OpenRailAssociation/technical-committee/blob/main/MAINTAINERS.md
+  member:
+    - cornelius # appointed
+    - Keller-Peter # appointed
+    - loic-hamelin # appointed
+    - mxmehl # permanent guest, OpenRail Team
+  repos:
     # GitHub Team Management
     openrail-org-config: push


### PR DESCRIPTION
Fixes https://github.com/OpenRailAssociation/technical-committee/issues/108

List of accounts taken from here: https://github.com/OpenRailAssociation/technical-committee/pull/115

This should enable us to assign TC members to issues.