### PR TITLE
Adapt to new command structure of github-org-manager

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -27,4 +27,4 @@ jobs:
         run: sed -i "s|__GITHUB_TOKEN__|${{ secrets.GTHB_TOKEN }}|" app.yaml
       - name: Synchronise settings with github-org-manager
         if: github.ref == 'refs/heads/main'
-        run: gh-org-mgr -c .
+        run: gh-org-mgr sync -c .


### PR DESCRIPTION
Version 0.4.0 changed the command structure.