### PR TITLE
Add RCM-DX team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # ----
 *                     @mxmehl @cornelius
 /teams/osrd.yaml      @openrailassociation/OSRD-Admins
+/teams/rcm-dx.yaml      @openrailassociation/RCM-DX
 /teams/technical-committee.yaml      @openrailassociation/Technical-Committee-Maintainers

--- a/teams/rcm-dx.yaml
+++ b/teams/rcm-dx.yaml
@@ -1,0 +1,10 @@
+RCM-DX:
+  description: The team behind the RCM-DX project
+  member:
+    - Jean-FredericBonjour
+    - schalbts
+    - tongpu
+  repos:
+    rcm-dx: admin
+    # GitHub Team Management
+    openrail-org-config: push


### PR DESCRIPTION
As soon as the repository is migrated to OpenRail, this provides the necessary permissions.

Names provided by SBB's @tongpu