### PR TITLE
Add Technical Committee to annual report repo

### DIFF
--- a/teams/internal-projects.yaml
+++ b/teams/internal-projects.yaml
@@ -43,8 +43,14 @@ OpenRail DNS Records:
 Annual Report:
   parent: Administrative Projects
   description: Maintainers of https://github.com/OpenRailAssociation/annual-report
-  member:
+  maintainer:
     - cornelius
     - Keller-Peter
+  member:
+    - aiAdrian # NGE
+    - flomonster # OSRD
+    - frederik-db # DAC-DSS
+    - schalbts # RCM
+    - Tristramg # liblrs
   repos:
     annual-report: maintain

--- a/teams/internal-projects.yaml
+++ b/teams/internal-projects.yaml
@@ -43,14 +43,8 @@ OpenRail DNS Records:
 Annual Report:
   parent: Administrative Projects
   description: Maintainers of https://github.com/OpenRailAssociation/annual-report
-  maintainer:
+  member:
     - cornelius
     - Keller-Peter
-  member:
-    - aiAdrian # NGE
-    - flomonster # OSRD
-    - frederik-db # DAC-DSS
-    - schalbts # RCM
-    - Tristramg # liblrs
   repos:
     annual-report: maintain

--- a/teams/technical-committee.yaml
+++ b/teams/technical-committee.yaml
@@ -14,6 +14,7 @@ Technical Committee:
     - Tristramg # liblrs
   repos:
     technical-committee: push
+    annual-report: push
 
 Technical Committee Maintainers:
   parent: Technical Committee


### PR DESCRIPTION
Add representatives of OpenRail projects, so we can assign issues in the annual-report repo to them.

I'm not completely sure, if this is the right way to do it. Could we also assign the technicall-committee group here, maybe?

Closes issue https://github.com/OpenRailAssociation/annual-report/issues/14