### PR TITLE
Set up Netzgrafikeditor team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 /teams/rcm-dx.yaml      @openrailassociation/RCM-DX
 /teams/technical-committee.yaml      @openrailassociation/Technical-Committee-Maintainers
 /teams/liblrs.yaml      @openrailassociation/liblrs-admins
-
+/teams/nge.yaml      @openrailassociation/NGE-Admins

--- a/teams/nge.yaml
+++ b/teams/nge.yaml
@@ -1,0 +1,26 @@
+# ------------------------------------------------------------------------------
+# Netzgrafikeditor
+# ------------------------------------------------------------------------------
+NGE:
+  description: Members of the Netzgrafikeditor project
+  maintainer:
+    - aiAdrian
+    - louisgreiner
+    - tongpu
+  member:
+    - Caracol3
+  repos:
+    netzgrafik-editor-backend: push
+    netzgrafik-editor-frontend: push
+    # GitHub Team Management
+    openrail-org-config: push
+
+NGE-Admins:
+  parent: NGE
+  member:
+    - aiAdrian
+    - louisgreiner
+    - tongpu
+  repos:
+    netzgrafik-editor-backend: admin
+    netzgrafik-editor-frontend: admin


### PR DESCRIPTION
Replaces https://github.com/OpenRailAssociation/openrail-org-config/pull/64 from maintainer branch. Also setting up Codeowners.

To be merged once the migration is done, see https://github.com/OpenRailAssociation/technical-committee/issues/120