### PR TITLE
Fix used version of github-org-manager, updates via renovate

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install github-org-manager
-        run: pip install github-org-manager
+        run: pip install -r requirements.txt
       - name: Display information about github-org-manager
         run: gh-org-mgr --version
       # Make a dry run in pull requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+github-org-manager==0.7.3


### PR DESCRIPTION
Avoid that different workflows and users run different versions of the upstream tool.

Also supersedes #80 