### PR TITLE
Exchange organization owners, small cleanups

### DIFF
--- a/org.yaml
+++ b/org.yaml
@@ -7,7 +7,7 @@ org_name: OpenRailAssociation
 # List of owners of the GitHub organisation
 org_owners:
   - cornelius
-  - loic-hamelin
+  - flomonster
   - mxmehl
 
 # Default settings. Will be overridden if set in a team.

--- a/teams/technical-committee.yaml
+++ b/teams/technical-committee.yaml
@@ -8,8 +8,12 @@ Technical Committee:
   description: The Technical Committee of the OpenRail Association
   member:
     - aiAdrian # NGE
+    - cornelius # appointed by BoD
     - flomonster # OSRD
     - frederik-db # DAC-DSS
+    - Keller-Peter # appointed by BoD
+    - loic-hamelin # appointed by BoD
+    - mxmehl # permanent guest, OpenRail Team
     - schalbts # RCM
     - Tristramg # liblrs
   repos:
@@ -21,12 +25,12 @@ Technical Committee Maintainers:
   parent: Technical Committee
   # The maintainers of the TC repo:
   # https://github.com/OpenRailAssociation/technical-committee/blob/main/MAINTAINERS.md
-  description: The maintainers of OpenRail Association's Technical Committee
+  description: The maintainers of the Technical Committee repository
   member:
-    - cornelius # appointed
-    - Keller-Peter # appointed
-    - loic-hamelin # appointed
-    - mxmehl # permanent guest, OpenRail Team
+    - cornelius
+    - Keller-Peter
+    - loic-hamelin
+    - mxmehl
   repos:
     # GitHub Team Management
     openrail-org-config: push


### PR DESCRIPTION
As discussed in Signal group, @flomonster is supposed to co-own the organization as TC Chair, superseding @loic-hamelin who held this role before.

Also, a minor cleanup or clarification in the TC teams, no effective change.