### PR TITLE
osrd: remove tests maintainers team

### DIFF
--- a/teams/osrd.yaml
+++ b/teams/osrd.yaml
@@ -132,12 +132,6 @@ OSRD-E2E-Tests:
     - Synar
     - Yohh
 
-OSRD-Tests:
-  parent: OSRD-Maintainers
-  maintainer:
-    - eckter
-    - shenriotpro
-
 OSRD-Data:
   parent: OSRD-Maintainers
   maintainer:


### PR DESCRIPTION
Blocked by: https://github.com/OpenRailAssociation/osrd/pull/15799