### PR TITLE
Give OpenRail Team access to working group boards

### DIFF
--- a/teams/general.yaml
+++ b/teams/general.yaml
@@ -20,6 +20,9 @@ OpenRail Team:
     website: push
     # GitHub Team Management
     openrail-org-config: push
+    # Boards of the working groups
+    ecosystem-developer-coordination-team-private: push
+    wg-project-scouting-private: push
 
 Event Organization Team:
   description: The members of the team organizing events


### PR DESCRIPTION
As decided at the last OpenRail Team meeting we give the team access to the boards to the working groups.