### PR TITLE
Remove the event organization team

### DIFF
--- a/teams/general.yaml
+++ b/teams/general.yaml
@@ -23,17 +23,3 @@ OpenRail Team:
     # Boards of the working groups
     ecosystem-developer-coordination-team-private: push
     wg-project-scouting-private: push
-
-Event Organization Team:
-  description: The members of the team organizing events
-  member:
-    - celine-sncf
-    - ConstanceDragibus
-    - cornelius
-    - loic-hamelin
-    - schalbts
-    - MelanieWollnik
-    - emersion
-    - LaureenFrederic
-  repos:
-    event-organization-private: push


### PR DESCRIPTION
The event is done. The team was used for the Kanban board. We will delete that.