### PR TITLE
Grant NGE frontend push permission to all OSRD members

### DIFF
--- a/teams/nge.yaml
+++ b/teams/nge.yaml
@@ -7,24 +7,6 @@ NGE:
     - aiAdrian
     - louisgreiner
     - tongpu
-  member:
-    - Caracol3
-    - emersion
-    - clarani
-    - Math-R
-    - SharglutDev
-    - kmer2016
-    - jacomyal
-    - anisometropie
-    - Synar
-    - Uriel-Sautron
-    - Yohh
-    - SarahBellaha
-    - maelysLeratRosso
-    - Maymanaf
-    - achrafmohye
-    - shenriotpro
-    - Pivouane
   repos:
     netzgrafik-editor-backend: push
     netzgrafik-editor-frontend: push

--- a/teams/osrd.yaml
+++ b/teams/osrd.yaml
@@ -62,6 +62,8 @@ OSRD:
     openrail-org-config: push
     # DNS Records
     openrail-dns: push
+    # NGE frontend, because OSRD members are regular contributors
+    netzgrafik-editor-frontend: push
 
 OSRD-Admins:
   parent: OSRD


### PR DESCRIPTION
OSRD members regularly contribute to NGE, so they need push access to create their own branches and be assignable as reviewers.

Up until now, we were manually duplicating OSRD frontend folks on the NGE configuration side. The old list has grown pretty outdated.

To avoid having to maintain two lists, grant push permission to all OSRD members for NGE's frontend repository.