### PR TITLE
ci: restrict some workflows to only run upstream

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -15,6 +15,7 @@ permissions: {}
 jobs:
   zizmor:
     runs-on: ubuntu-latest
+    if: github.repository == 'OpenRailAssociation/openrail-org-config'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 OpenRail Association AISBL
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: CI security tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -9,11 +9,16 @@ on:
   schedule:
     - cron: "25 3 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   sync-settings:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:


### PR DESCRIPTION
Adds `if: github.repository == '...'` condition to release-please, ci-security, and/or release-vulnerabilities workflows so they only run in the upstream repository, not in forks.