### PR TITLE
Add openrail-contacts-private repository access

### DIFF
--- a/teams/general.yaml
+++ b/teams/general.yaml
@@ -17,6 +17,7 @@ OpenRail Team:
     - vlasceanuic
   repos:
     openrail-team-private: push
+    openrail-contacts-private: push
     website: push
     # GitHub Team Management
     openrail-org-config: push


### PR DESCRIPTION
Repo used as base for the contact list, which is implemented as GitHub Project for now.