### PR TITLE
Add team for AMS project

### DIFF
--- a/teams/project-ams.yaml
+++ b/teams/project-ams.yaml
@@ -1,0 +1,9 @@
+AMS:
+  description: Members of the AMS project
+  member:
+    - loic-hamelin
+    - SimonClavier
+  repos:
+    ams: push
+    # GitHub Team Management
+    openrail-org-config: push


### PR DESCRIPTION
Add a team configuration for the AMS project with initial members loic-hamelin and SimonClavier.